### PR TITLE
release v0.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ IMAGE_PUSH_TARGETS = $(TARGETS:=.push-image)
 MANIFEST_CREATE_TARGETS = $(PLATFORM:=.create-manifest)
 MANIFEST_PUSH_TARGETS = $(PLATFORM:=.push-manifest)
 BUILD_OPT=""
-IMAGE_TAG=0.3
+IMAGE_TAG=0.4
 IMAGE_PREFIX=k8s-fuse-plugin
 IMAGE_REGISTRY=quay.io/nextflow
 BINARY=k8s-fuse-plugin

--- a/manifests/k8s-fuse-plugin.yml
+++ b/manifests/k8s-fuse-plugin.yml
@@ -14,7 +14,7 @@ spec:
     spec:
       hostNetwork: true
       containers:
-      - image: quay.io/nextflow/k8s-fuse-plugin:0.3
+      - image: quay.io/nextflow/k8s-fuse-plugin:0.4
         args:
           - "--mounts-allowed=5000"
         name: fuse-device-plugin-ctr


### PR DESCRIPTION
## Summary

- Bump image tag to 0.4 in Makefile and manifests
- Includes security fix: upgrade grpc-go to v1.80.0 (CVE-2026-33186)

## Post-merge steps

1. Tag the merge commit: `git tag v0.4 && git push origin v0.4`
2. Build and push Docker images: `make all`